### PR TITLE
Add optional date range filtering

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,12 +3,29 @@ from src.logging_config import setup_logging
 import logging
 from src.constants import RAW_PULL_REQUESTS_PATH, PROCESSED_REPORT_PATH
 from src.transform import process_pull_requests
+import argparse
 
 def main():
     setup_logging()
     logger = logging.getLogger(__name__)
-    logger.info("--- Starting GitHub PR Analysis ---")
 
+    # -- Parse command line arguments setup --
+    parser = argparse.ArgumentParser(description="Fetch and analyze GitHub PRs for compliance.")
+    parser.add_argument(
+        "--start-date",
+        type=str,
+        help="Filter PRs merged on or after this date. Format: YYYY-MM-DD"
+    )
+    parser.add_argument(
+        "--end-date",
+        type=str,
+        help="Filter PRs merged on or before this date. Format: YYYY-MM-DD"
+    )
+    # -- Parse command line arguments --
+    args = parser.parse_args()
+    logger.info("--- Starting GitHub PR Analysis ---")
+    if args.start_date or args.end_date:
+        logger.info(f"Running with date filter: Start: {args.start_date}, End: {args.end_date}")
 
     logger.info(">>> Step 1: Extracting data from GitHub...")
     try:
@@ -21,7 +38,12 @@ def main():
 
     logger.info(">>> Step 2: Processing data...")
     try:
-        process_pull_requests(input_path=RAW_PULL_REQUESTS_PATH, output_path=PROCESSED_REPORT_PATH)
+        process_pull_requests(
+            input_path=RAW_PULL_REQUESTS_PATH,
+            output_path=PROCESSED_REPORT_PATH,
+            start_date=args.start_date if args.start_date else None,
+            end_date=args.end_date if args.end_date else None
+        )
     except Exception as e:
         logger.exception(f"An error occurred during data transformation: {e}")
         return


### PR DESCRIPTION
### What does this PR do?
This pull request introduces the ability to filter pull requests by a specified date range using command-line arguments.

### Key Changes:
- **`main.py`:** The `argparse` module is now used to define and parse two optional arguments: `--start-date` and `--end-date`.
- **`transform.py`:** The `process_pull_requests` function was updated to accept the date strings. It now filters the main DataFrame based on the provided dates *before* initiating the expensive enrichment API calls, which improves efficiency.

### Why is this change being made?
This feature makes the tool significantly more flexible and useful for targeted analysis (e.g., generating a compliance report for a specific quarter or year).

### How to test this change?
The script can now be run with the new flags:
```bash
# Run for a specific date range
python main.py --start-date 2023-01-01 --end-date 2023-12-31

# Run for all PRs after a certain date
python main.py --start-date 2024-01-01

# Run without filters (should behave as before)
python main.py
```
Verify that the output `pr_report.csv` contains only the records that fall within the specified date range.